### PR TITLE
Use "onevent" instead of "watch" in the watch example

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ htcondor.submit(submit_options).then(function(job) {
     //console.dir(job.id);
 
     //you can *watch* job log
-    job.log.watch(function(event) {
+    job.log.onevent(function(event) {
         switch(event.MyType) {
 
         //normal status type events (just display content)


### PR DESCRIPTION
The watch example uses:
`job.log.watch(function(event) { ... }`
Unfortunately, the `JobLog` provides `onevent` instead of `watch` and the example does not work.

I changed the function name in this PR.